### PR TITLE
Add verbosity flag to test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 0.1.1 (Unreleased)
+
+- Add `verbosity` flag to `test` command [[GH-13](https://github.com/umbracle/greenhouse/issues/13)]
+
 ## 0.1.0 (January 17, 2022)
 
 Initial Public Release

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -3,18 +3,24 @@ package cli
 import (
 	"fmt"
 	"strings"
+
+	flag "github.com/spf13/pflag"
 )
 
 // TestCommand is the command to test the Solidity project
 type TestCommand struct {
 	*baseCommand
+
+	verbose bool
 }
 
 // Help implements the cli.Command interface
 func (b *TestCommand) Help() string {
 	return `Usage: greenhouse test
 
-  Test the project`
+  Test the project
+
+` + b.Flags().FlagUsages()
 }
 
 // Synopsis implements the cli.Command interface
@@ -22,9 +28,17 @@ func (b *TestCommand) Synopsis() string {
 	return "Test the project"
 }
 
+func (b *TestCommand) Flags() *flag.FlagSet {
+	flags := b.baseCommand.Flags("test")
+
+	flags.BoolVarP(&b.verbose, "verbose", "v", false, "Show in stdout the output of the test")
+
+	return flags
+}
+
 // Run implements the cli.Command interface
 func (b *TestCommand) Run(args []string) int {
-	flags := b.Flags("test")
+	flags := b.Flags()
 	if err := flags.Parse(args); err != nil {
 		b.UI.Error(err.Error())
 		return 1
@@ -34,6 +48,7 @@ func (b *TestCommand) Run(args []string) int {
 		b.UI.Error(err.Error())
 		return 1
 	}
+
 	outputs, err := b.project.Test()
 	if err != nil {
 		b.UI.Error(err.Error())
@@ -48,8 +63,10 @@ func (b *TestCommand) Run(args []string) int {
 			res = "[red]failed[reset]"
 		}
 		b.UI.Output(b.Colorize().Color(fmt.Sprintf("  %s:%s:%s (%s)", o.Source, o.Contract, o.Method, res)))
-		for _, console := range o.Console {
-			b.UI.Output("[" + strings.Join(console.Val, ", ") + "]")
+		if b.verbose {
+			for _, console := range o.Console {
+				b.UI.Output("[" + strings.Join(console.Val, ", ") + "]")
+			}
 		}
 	}
 	return 0

--- a/version/version.go
+++ b/version/version.go
@@ -7,10 +7,10 @@ var (
 	GitCommit string
 
 	// Version is the main version at the moment.
-	Version = "0.1.0"
+	Version = "0.1.1"
 
 	// VersionPrerelease is a marker for the version.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetVersion returns a string representation of the version


### PR DESCRIPTION
This PR adds a new `verbosity` flag to determine whether the `test` command should output console logs or not.